### PR TITLE
Potential fix for code scanning alert no. 22: Insecure randomness

### DIFF
--- a/frontend/src/components/SMSAuthScreen.jsx
+++ b/frontend/src/components/SMSAuthScreen.jsx
@@ -42,20 +42,38 @@ export default function SMSAuthScreen() {
     const symbols = '!@#$%^&*';
     const allChars = upper + lower + digits + symbols;
 
+    // Helper: cryptographically secure random integer in [0, max)
+    const getSecureRandomInt = (max) => {
+      if (max <= 0) {
+        throw new Error('max must be positive');
+      }
+      const array = new Uint32Array(1);
+      window.crypto.getRandomValues(array);
+      // Use modulo to map into range; bias is negligible for these small ranges.
+      return array[0] % max;
+    };
+
     let password = '';
     // Ensure at least one of each type
-    password += upper[Math.floor(Math.random() * upper.length)];
-    password += lower[Math.floor(Math.random() * lower.length)];
-    password += digits[Math.floor(Math.random() * digits.length)];
-    password += symbols[Math.floor(Math.random() * symbols.length)];
+    password += upper[getSecureRandomInt(upper.length)];
+    password += lower[getSecureRandomInt(lower.length)];
+    password += digits[getSecureRandomInt(digits.length)];
+    password += symbols[getSecureRandomInt(symbols.length)];
 
     // Fill the rest randomly (16 chars total)
     for (let i = password.length; i < 16; i++) {
-      password += allChars[Math.floor(Math.random() * allChars.length)];
+      password += allChars[getSecureRandomInt(allChars.length)];
     }
 
-    // Shuffle password
-    return password.split('').sort(() => Math.random() - 0.5).join('');
+    // Shuffle password using Fisher–Yates with secure randomness
+    const chars = password.split('');
+    for (let i = chars.length - 1; i > 0; i--) {
+      const j = getSecureRandomInt(i + 1);
+      const tmp = chars[i];
+      chars[i] = chars[j];
+      chars[j] = tmp;
+    }
+    return chars.join('');
   };
 
   const handleGeneratePassword = () => {


### PR DESCRIPTION
Potential fix for [https://github.com/echetoui/scamguard-mvp/security/code-scanning/22](https://github.com/echetoui/scamguard-mvp/security/code-scanning/22)

In general, the fix is to replace `Math.random()` with a cryptographically secure random source when generating passwords. In a browser-based React component, you should use `window.crypto.getRandomValues` (or `self.crypto` / `globalThis.crypto`) to draw random bytes, and then map those bytes into indices for your character sets without introducing significant bias.

The best fix here is to (1) add a small helper that gets a cryptographically secure random integer in a given range using `window.crypto.getRandomValues(new Uint32Array(1))`, and (2) use that helper everywhere the code currently calls `Math.random()` to select characters and to shuffle. This keeps the overall behavior (16-character password with at least one uppercase, lowercase, digit, and symbol, then shuffled) while just changing the randomness source. Because `window.crypto` is a standard Web API, no new dependency is needed, and no other parts of the file need to change.

Concretely, in `frontend/src/components/SMSAuthScreen.jsx` within the `generatePassword` function, introduce a `getSecureRandomInt(max)` helper that returns a secure integer in `[0, max)`, then:

- Replace each `Math.floor(Math.random() * upper.length)` / `lower.length` / `digits.length` / `symbols.length` / `allChars.length` with `getSecureRandomInt(<corresponding>.length)`.
- Replace the shuffle logic `password.split('').sort(() => Math.random() - 0.5)` with a proper Fisher–Yates shuffle using `getSecureRandomInt` to choose indices.

No new imports are required, as `window.crypto` is globally available in browsers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
