### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/backend/gemini_integration.py
+++ b/backend/gemini_integration.py
@@ -96,7 +96,8 @@ class GeminiIntegration:
                 return result
             else:
                 self.error_count += 1
-                logger.error(f"Gemini API error: {response['error']}")
+                # Log a generic error message to avoid exposing potentially sensitive upstream details
+                logger.error("Gemini API error during analysis")
                 return self._error_response(response['error'])
 
         except Exception as e:
@@ -201,29 +202,37 @@ class GeminiIntegration:
                                 'data': result
                             }
                         except json.JSONDecodeError as e:
-                            logger.error(f"Failed to parse Gemini response: {content}")
+                            # Avoid logging full model output, which may contain user input or sensitive data
+                            logger.error(f"Failed to parse Gemini response JSON: {str(e)}")
                             return {
                                 'success': False,
-                                'error': f"Invalid JSON response: {str(e)}"
+                                'error': f"Invalid JSON response from Gemini"
                             }
 
-                logger.error(f"Unexpected Gemini response structure: {data}")
+                logger.error("Unexpected Gemini response structure")
                 return {
                     'success': False,
-                    'error': "Unexpected response structure"
+                    'error': "Unexpected response structure from Gemini"
                 }
             else:
-                error_msg = response.text
+                # Do not log full error body as it may contain sensitive information
                 try:
                     error_data = response.json()
-                    error_msg = error_data.get('error', {}).get('message', error_msg)
-                except:
-                    pass
+                    # Optionally extract a non-sensitive error code if available, but do not expose full message
+                    error_code = error_data.get('error', {}).get('code')
+                except Exception:
+                    error_code = None
 
-                logger.error(f"Gemini API error {response.status_code}: {error_msg}")
+                if error_code is not None:
+                    logger.error(f"Gemini API returned HTTP {response.status_code} with error code {error_code}")
+                    error_summary = f"API error {response.status_code} (code {error_code}) from Gemini"
+                else:
+                    logger.error(f"Gemini API returned HTTP {response.status_code}")
+                    error_summary = f"API error {response.status_code} from Gemini"
+
                 return {
                     'success': False,
-                    'error': f"API error {response.status_code}: {error_msg}"
+                    'error': error_summary
                 }
 
         except requests.Timeout:


### PR DESCRIPTION
Potential fix for [https://github.com/echetoui/scamguard-mvp/security/code-scanning/8](https://github.com/echetoui/scamguard-mvp/security/code-scanning/8)

General fix: avoid logging or returning any data that could contain secrets or API keys. Instead, log only generic, non-sensitive summaries (for example, status codes, high-level error categories) and keep detailed error messages internal or stripped of sensitive content. Ensure that anything derived from `api_key` or `SecretString` is never included in log messages.

Best fix here without changing existing functionality:

1. In `GeminiIntegration.analyze_text`:
   - Replace `logger.error(f"Gemini API error: {response['error']}")` with a generic error log that does not log the `error` string, e.g. log that an API error occurred and maybe include whether it was a client or server error, but not the raw text.
   - Optionally, keep returning `self._error_response(response['error'])` to the caller (this is not a log, just a return), since changing the shape of the response would alter functionality. If you want to be stricter you could also standardize this to a generic message, but I’ll preserve behavior.

2. In `GeminiIntegration._call_gemini_api`:
   - When JSON decode fails, do not log the full `content` string, as it comes from the LLM and could reflect input; instead, log a generic message and maybe the exception type.
   - When the response structure is unexpected, avoid logging the full `data` dict; log only that an unexpected structure was encountered.
   - In the non-200 case, stop logging `error_msg`, which is derived from `response.text` / `response.json()`. Log only the HTTP status code and maybe a short, static message.
   - When building the error returned in the dict (`'error': f"API error {response.status_code}: {error_msg}"`), remove `error_msg` and use a generic message. This addresses the taint path that ends up in `response['error']` and gets logged by `analyze_text`.

3. In `llm_enhanced_handler.get_secret`:
   - This function does not currently log the secret; just ensure we do not add any logging of `response` or `SecretString`. No code change is actually needed here for secrecy, but CodeQL’s taint is raised later when that secret flows into logs, which will be mitigated by the changes in `gemini_integration.py`.

4. In `llm_enhanced_handler.analyze_with_provider`:
   - The current logs (`logger.error(f"Error analyzing with {provider_name}: {str(e)}")`) do not appear to include the secret, but to be safe, keep logging generic and not any nested data structures that might contain the secret. The provided snippet does not show logs that directly contain `api_key`, so no change is necessary here to fix the reported issue.

All required changes are confined to `backend/gemini_integration.py`. No new imports or helper methods are needed; we only adjust logging messages and returned error strings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
