### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/echetoui/scamguard-mvp/security/code-scanning/1](https://github.com/echetoui/scamguard-mvp/security/code-scanning/1)

In general, the fix is to explicitly declare `permissions` for the `GITHUB_TOKEN` either at the workflow root (applies to all jobs) or per job, and restrict them to the minimum required. For this CI workflow, both jobs only check out code and run tests, which requires only read access to repository contents.

The best minimal change without altering functionality is to add a workflow-level `permissions` block right under the `name: CI` line, setting `contents: read`. This will constrain `GITHUB_TOKEN` for all jobs (`frontend-tests` and `backend-tests`) while preserving existing behavior: `actions/checkout` works with `contents: read`, and no step needs write permissions. No other lines or jobs need to be modified.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI`). No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
