### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/echetoui/scamguard-mvp/security/code-scanning/2](https://github.com/echetoui/scamguard-mvp/security/code-scanning/2)

In general, fix this by adding an explicit `permissions:` block that grants only the scopes needed by the job. Place it either at the top level of the workflow (to apply to all jobs) or inside the specific job. For this workflow, the job needs to: (1) read repository contents to run tests/linters, and (2) write PR comments for the coverage comment action. It does not need generic write access to repository contents.

The single best fix here is to add a job‑level `permissions:` block under `jobs.test:` before `runs-on:`. Set `contents: read` so actions like `actions/checkout` work with read-only repo access, and set `pull-requests: write` so `py-cov-action/python-coverage-comment-action` can post or update PR comments. No other scopes are obviously required from the shown steps, and we do not need to modify any steps or add imports.

Concretely:
- Edit `.github/workflows/test.yml`.
- Under `jobs:\n  test:`, insert:

```yaml
    permissions:
      contents: read
      pull-requests: write
```

- Keep indentation consistent (two spaces per level; four under `test:`).

No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
