### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,8 @@
 name: Security Scan
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [develop, main]
@@ -65,6 +68,9 @@ jobs:
 
   code-scanning:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/echetoui/scamguard-mvp/security/code-scanning/3](https://github.com/echetoui/scamguard-mvp/security/code-scanning/3)

To fix this, explicitly define `permissions:` in the workflow to avoid relying on repository defaults and to follow least-privilege. The safest pattern here is:

- At the top (workflow level), add a `permissions:` block that grants read-only access to repository contents, which is sufficient for `actions/checkout`, SonarCloud analysis, and artifact upload.
- For the `code-scanning` job, which posts a PR comment using `actions/github-script`, override the default with a job-level `permissions:` block that adds `pull-requests: write` (needed to create comments on PRs) while keeping `contents: read`.

Concretely:

- In `.github/workflows/security.yml`, after the `name: Security Scan` line (before `on:`), add:
  ```yaml
  permissions:
    contents: read
  ```
  This applies to all jobs.
- In the `code-scanning` job definition (just under `runs-on: ubuntu-latest` on line 67), add:
  ```yaml
      permissions:
        contents: read
        pull-requests: write
  ```
  maintaining indentation. This ensures that only `code-scanning` can write to PRs; the other jobs remain read-only.

No other functional changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
